### PR TITLE
Cython was required when I was installing it in RPi Ubuntu Mate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Cython==0.29.14
 future==0.17.1
 matplotlib==3.1.0
 numpy==1.16.4


### PR DESCRIPTION
Added Cython pre-requisite to requirements.py. I faced this problem when installing the package in RPi Ubuntu Mate. 