### PR TITLE
Add mcp3208 dependency used in code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pillow==6.2.0
 scikit-learn==0.21.2
 seaborn==0.9.0
 sphinx_rtd_theme==0.4.3
+mcp3208


### PR DESCRIPTION
Added mcp3208 dependency, which was required when running the code
1) Also, I suggest removing the versions in requirements.txt. The reason is some wheels with that specific version might not be directly available. Hence if we remove the dependency, then everything can be directly be installed.