### PR TITLE
Add imu information to trials, fix trial bug

### DIFF
--- a/robotic_skin/calibration/data_logger.py
+++ b/robotic_skin/calibration/data_logger.py
@@ -51,13 +51,13 @@ class DataLogger():
         self.average_euclidean_distance = np.mean(
             list(self.best_data['euclidean_distance'].values()))
 
-    def add_trial(self, global_step, **kwargs):
+    def add_trial(self, global_step, imu_num, **kwargs):
+        if global_step not in self.best_data:
+            self.trials[global_step] = {}
+        self.trials[global_step]['imu_num'] = imu_num
         for key, value in kwargs.items():
             if isinstance(value, np.ndarray):
                 value = value.tolist()
-
-            if global_step not in self.best_data:
-                self.trials[global_step] = {}
 
             self.trials[global_step][key] = value
 
@@ -68,7 +68,7 @@ class DataLogger():
             'best_data': self.best_data,
             'trials': self.trials}
         with open(self.savepath, 'wb') as f:
-            pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
+            pickle.dump(data, f, protocol=2)
 
     def __call__(self):
         print('Estimated SU Positions')

--- a/robotic_skin/calibration/optimizer.py
+++ b/robotic_skin/calibration/optimizer.py
@@ -262,6 +262,7 @@ class TorchOptimizerBase(IncrementalOptimizerBase):
         params = params.cpu().detach().numpy()
         self.data_logger.add_trial(
             global_step=self.global_step,
+            imu_num=self.i_su,
             params=params,
             position=pos,
             orientation=quat,
@@ -308,6 +309,7 @@ class TorchOptimizerBase(IncrementalOptimizerBase):
         # Log
         self.data_logger.add_trial(
             global_step=self.global_step,
+            imu_num=self.i_su,
             params=params,
             position=T.position,
             orientation=T.quaternion,
@@ -479,6 +481,7 @@ class MixedIncrementalOptimizer(IncrementalOptimizerBase):
         # Log
         self.data_logger.add_trial(
             global_step=self.global_step,
+            imu_num=self.i_su,
             params=params,
             position=T.position,
             orientation=T.quaternion,
@@ -603,6 +606,7 @@ class SeparateIncrementalOptimizer(IncrementalOptimizerBase):
         # Log
         self.data_logger.add_trial(
             global_step=self.global_step,
+            imu_num=self.i_su,
             params=params,
             position=T.position,
             orientation=T.quaternion,


### PR DESCRIPTION
This PR adds information for the current imu being optimized. Additionally, this fixes a bug where only one piece of information (per global step) is being added.