### PR TITLE
Calibrate Accelerometer

### DIFF
--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -16,6 +16,7 @@ class LSM6DS3_IMU(Sensor):
     This is the Python Class for LSM6DS3. This includes all subroutines including calibration to handle everything
     related to the device.
     """
+
     def __init__(self, config_file):  # noqa: E999
         """
         Initializes the LSM6DS3 accelerometer. Checks for the I2C connection and checks whether it's the correct
@@ -206,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.000488 * GRAVITATIONAL_CONSTANT
+        ax = self.make_16bit_value(axh, axl) * GRAVITATIONAL_CONSTANT
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.000488 * GRAVITATIONAL_CONSTANT
+        ay = self.make_16bit_value(ayh, ayl) * GRAVITATIONAL_CONSTANT
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.000488 * GRAVITATIONAL_CONSTANT
+        az = self.make_16bit_value(azh, azl) * GRAVITATIONAL_CONSTANT
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)
@@ -255,9 +256,9 @@ class LSM6DS3_IMU(Sensor):
         """
         return [self._calibrate_value(each_value) for each_value in self._read_raw()]
 
+
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
         print(lsm6ds3.read()[0:3])
         sleep(0.5)
-

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
+        ax = self.make_16bit_value(axh, axl) * GRAVITATIONAL_CONSTANT
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
+        ay = self.make_16bit_value(ayh, ayl) * GRAVITATIONAL_CONSTANT
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
+        az = self.make_16bit_value(azh, azl) * GRAVITATIONAL_CONSTANT
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -4,7 +4,6 @@ https://github.com/CRImier/python-lsm6ds3
 Thanks Homie!
 Datasheet Link: https://cdn.sparkfun.com/assets/learn_tutorials/4/1/6/DM00133076.pdf
 """
-import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -206,13 +206,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.002
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.002
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.002
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -253,3 +253,8 @@ class LSM6DS3_IMU(Sensor):
 
         """
         return [self._calibrate_value(each_value) for each_value in self._read_raw()]
+
+if __name__ == "__main__":
+    lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
+    print(lsm6ds3.read())
+

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * GRAVITATIONAL_CONSTANT
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * GRAVITATIONAL_CONSTANT
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * GRAVITATIONAL_CONSTANT
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001  # This should go to calibrate
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT  # This should go to calibrate
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001  # This should go to calibrate
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT  # This should go to calibrate
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001  # This should go to calibrate
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT  # This should go to calibrate
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)
@@ -256,8 +256,12 @@ class LSM6DS3_IMU(Sensor):
         """
         return [self._calibrate_value(each_value) for each_value in self._read_raw()]
 
+
 # useful for debugging
 if __name__ == "__main__":
+    # A ROS Pkg can be used and the config file can be passed so that there is no need of
+    # hard coding the path. But this main function is used to debug to check the functionality
+    # of the driver.
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
         print(lsm6ds3.read()[0:3])

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -142,8 +142,8 @@ class LSM6DS3_IMU(Sensor):
         """
 
         v = (vh << 8) | vl
-        return v
-        # return (self.twos_comp(v, 16)) / math.pow(2, 14)
+        # return v
+        return (self.twos_comp(v, 16)) / math.pow(2, 14)
 
     def twos_comp(self, val, num_of_bits):
         """

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * GRAVITATIONAL_CONSTANT
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.008
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * GRAVITATIONAL_CONSTANT
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.008
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * GRAVITATIONAL_CONSTANT
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.008
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,8 +8,6 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
-from time import sleep
-import numpy as np
 
 
 class LSM6DS3_IMU(Sensor):
@@ -144,7 +142,7 @@ class LSM6DS3_IMU(Sensor):
 
         v = vl | (vh << 8)
         # return v
-        return (self.twos_comp(v, 16)) #/ math.pow(2, 14)
+        return (self.twos_comp(v, 16))  # / math.pow(2, 14)
 
     def twos_comp(self, val, num_of_bits):
         """
@@ -208,13 +206,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.002
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001  # This should go to calibrate
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.002
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001  # This should go to calibrate
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.002
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001  # This should go to calibrate
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)
@@ -257,9 +255,8 @@ class LSM6DS3_IMU(Sensor):
         """
         return [self._calibrate_value(each_value) for each_value in self._read_raw()]
 
-
+# useful for debugging
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
-        print(np.linalg.norm(lsm6ds3.read()[0:3]))
-        sleep(0.5)
+        print(lsm6ds3.read()[0:3])

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -141,7 +141,8 @@ class LSM6DS3_IMU(Sensor):
             Acceleration Value in G
         """
 
-        v = (vh << 8) | vl
+        # v = (vh << 8) | vl
+        v = (vl << 8) | vh
         return v
         # return (self.twos_comp(v, 16)) / math.pow(2, 14)
 

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -206,13 +206,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * GRAVITATIONAL_CONSTANT
+        ax = self.make_16bit_value(axh, axl) * 0.000488 * GRAVITATIONAL_CONSTANT
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * GRAVITATIONAL_CONSTANT
+        ay = self.make_16bit_value(ayh, ayl) * 0.000488 * GRAVITATIONAL_CONSTANT
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * GRAVITATIONAL_CONSTANT
+        az = self.make_16bit_value(azh, azl) * 0.000488 * GRAVITATIONAL_CONSTANT
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.008
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.008
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.008
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,6 +8,8 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
+import numpy as np
+from time import sleep
 
 
 class LSM6DS3_IMU(Sensor):
@@ -259,4 +261,5 @@ class LSM6DS3_IMU(Sensor):
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
-        print(lsm6ds3.read()[0:3])
+        print(np.linalg.norm(lsm6ds3.read()[0:3]))
+        sleep(0.5)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -207,13 +207,13 @@ class LSM6DS3_IMU(Sensor):
     def _read_raw(self):
         axh = self.read_reg(self.OUTX_H_XL)
         axl = self.read_reg(self.OUTX_L_XL)
-        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
+        ax = self.make_16bit_value(axh, axl) * 0.061 * 0.001
         ayh = self.read_reg(self.OUTY_H_XL)
         ayl = self.read_reg(self.OUTY_L_XL)
-        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
+        ay = self.make_16bit_value(ayh, ayl) * 0.061 * 0.001
         azh = self.read_reg(self.OUTZ_H_XL)
         azl = self.read_reg(self.OUTZ_L_XL)
-        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001 * GRAVITATIONAL_CONSTANT
+        az = self.make_16bit_value(azh, azl) * 0.061 * 0.001
         gxh = self.read_reg(self.OUTX_H_G)
         gxl = self.read_reg(self.OUTX_L_G)
         gx = self.make_16bit_value(gxh, gxl)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -141,8 +141,8 @@ class LSM6DS3_IMU(Sensor):
         """
 
         v = (vh << 8) | vl
-        # return v
-        return (self.twos_comp(v, 16)) / math.pow(2, 14)
+        return v
+        # return (self.twos_comp(v, 16)) / math.pow(2, 14)
 
     def twos_comp(self, val, num_of_bits):
         """

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,6 +8,7 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
+from time import sleep
 
 
 class LSM6DS3_IMU(Sensor):
@@ -260,3 +261,4 @@ if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
         print(lsm6ds3.read()[0:3])
+        sleep(0.5)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -142,8 +142,8 @@ class LSM6DS3_IMU(Sensor):
         """
 
         v = (vh << 8) | vl
-        # return v
-        return (self.twos_comp(v, 16)) / math.pow(2, 14)
+        return v
+        # return (self.twos_comp(v, 16)) / math.pow(2, 14)
 
     def twos_comp(self, val, num_of_bits):
         """

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -258,4 +258,5 @@ class LSM6DS3_IMU(Sensor):
 
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
-    print(lsm6ds3.read_reg(lsm6ds3.CTRL1_XL))
+    while 1:
+        print(lsm6ds3.read()[0:3])

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -141,8 +141,7 @@ class LSM6DS3_IMU(Sensor):
             Acceleration Value in G
         """
 
-        # v = (vh << 8) | vl
-        v = (vl << 8) | vh
+        v = vl | (vh << 8)
         return v
         # return (self.twos_comp(v, 16)) / math.pow(2, 14)
 

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,6 +8,7 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
+from time import sleep
 
 
 class LSM6DS3_IMU(Sensor):
@@ -258,4 +259,5 @@ if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
         print(lsm6ds3.read())
+        sleep(0.5)
 

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -142,8 +142,8 @@ class LSM6DS3_IMU(Sensor):
         """
 
         v = vl | (vh << 8)
-        return v
-        # return (self.twos_comp(v, 16)) / math.pow(2, 14)
+        # return v
+        return (self.twos_comp(v, 16)) #/ math.pow(2, 14)
 
     def twos_comp(self, val, num_of_bits):
         """

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,8 +8,6 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
-from time import sleep
-import numpy as np
 
 
 class LSM6DS3_IMU(Sensor):
@@ -260,6 +258,4 @@ class LSM6DS3_IMU(Sensor):
 
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
-    while 1:
-        print(np.linalg.norm(lsm6ds3.read()[0:3]))
-        sleep(0.5)
+    print(lsm6ds3.read_reg(lsm6ds3.CTRL1_XL))

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -8,7 +8,6 @@ import math
 import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
-import numpy as np
 from time import sleep
 
 
@@ -261,5 +260,5 @@ class LSM6DS3_IMU(Sensor):
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
-        print(np.linalg.norm(lsm6ds3.read()[0:3]))
+        print(lsm6ds3.read()[0:3])
         sleep(0.5)

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -256,5 +256,6 @@ class LSM6DS3_IMU(Sensor):
 
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
-    print(lsm6ds3.read())
+    while 1:
+        print(lsm6ds3.read())
 

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -258,6 +258,6 @@ class LSM6DS3_IMU(Sensor):
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
-        print(lsm6ds3.read())
+        print(lsm6ds3.read()[0:3])
         sleep(0.5)
 

--- a/robotic_skin/sensor/lsm6ds3.py
+++ b/robotic_skin/sensor/lsm6ds3.py
@@ -9,6 +9,7 @@ import smbus2
 from robotic_skin.sensor import Sensor
 from robotic_skin.const import GRAVITATIONAL_CONSTANT
 from time import sleep
+import numpy as np
 
 
 class LSM6DS3_IMU(Sensor):
@@ -260,5 +261,5 @@ class LSM6DS3_IMU(Sensor):
 if __name__ == "__main__":
     lsm6ds3 = LSM6DS3_IMU("/home/hiro/catkin_ws/src/ros_robotic_skin/config/accelerometer_config1.yaml")
     while 1:
-        print(lsm6ds3.read()[0:3])
+        print(np.linalg.norm(lsm6ds3.read()[0:3]))
         sleep(0.5)


### PR DESCRIPTION
- Accelerometer LSM6DS3 calibrated
- The formula used is 
`raw_acceleration_value * 0.061 * (accelerometer_range >> 1) / 1000;`
The above formula is obtained from https://github.com/sparkfun/SparkFun_LSM6DS3_Arduino_Library/blob/master/src/SparkFunLSM6DS3.cpp#L663
- The accelerometer range can be obtained from the CTRL1_XL register's 5th and 6th bits. So if the bits are default which is 00 then the range is +-2G and the accelerometer_range in the above formula should be substituted as 2.
- The constant 0.061 is obtained from the datasheet Chapter 4 Mechanical Characteristics, table-3 Linear acceleration sensitivities

In the final calibration when the G and accelerometer z are in opposite direction the L2 norm of the X, Y, Z accelerations in G is approximately 1.0+e and when G and accelerometer z are in the same direction then the norm is 0.98+e